### PR TITLE
Add an API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # Improved Group View
 
 Allows more than 20 groups to show in the groups menu!
+
+# For developers
+
+This mod exposes an API that allows you to post events to refresh the new group menu. It works both as a `required` and an optional (`recommended`/`suggested`) dependency.
+
+## Usage:
+
+In your source file, put\
+`#include <alphalaneous.improved_group_view/api/GroupViewUpdateEvent.hpp>`
+
+Then, whenever you want to update the group view just call\
+`igv::GroupViewUpdateEvent().post()`

--- a/about.md
+++ b/about.md
@@ -1,3 +1,15 @@
 # Improved Group View
 
 Allows more than 20 groups to show in the groups menu!
+
+# For developers
+
+This mod exposes an API that allows you to post events to refresh the new group menu. It works both as a `required` and an optional (`recommended`/`suggested`) dependency.
+
+## Usage:
+
+In your source file, put\
+`#include <alphalaneous.improved_group_view/api/GroupViewUpdateEvent.hpp>`
+
+Then, whenever you want to update the group view just call\
+`igv::GroupViewUpdateEvent().post()`

--- a/api/GroupViewUpdateEvent.hpp
+++ b/api/GroupViewUpdateEvent.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <Geode/loader/Event.hpp>
+
+class GroupViewUpdateEvent final : public geode::Event {
+public:
+    GroupViewUpdateEvent() : geode::Event() {}
+};

--- a/api/GroupViewUpdateEvent.hpp
+++ b/api/GroupViewUpdateEvent.hpp
@@ -2,7 +2,6 @@
 
 #include <Geode/loader/Event.hpp>
 
-class GroupViewUpdateEvent final : public geode::Event {
-public:
-    GroupViewUpdateEvent() : geode::Event() {}
-};
+namespace igv {
+    struct GroupViewUpdateEvent final : geode::Event {};
+}

--- a/mod.json
+++ b/mod.json
@@ -43,6 +43,6 @@
         }
 	},
 	"tags": [
-		"editor", "enhancement", "api"
+		"editor", "enhancement"
 	]
 }

--- a/mod.json
+++ b/mod.json
@@ -1,5 +1,5 @@
 {
-	"geode": "4.6.3",
+	"geode": "4.7.0",
 	"gd": {
 		"win": "2.2074",
 		"android": "2.2074",
@@ -35,7 +35,6 @@
 	},
 	"settings": {
 		"left-align": {
-			
             "name": "Left Align Groups",
 			"description": "Align groups to the left like vanilla GD",
             "type": "bool",

--- a/mod.json
+++ b/mod.json
@@ -1,5 +1,5 @@
 {
-	"geode": "4.3.1",
+	"geode": "4.6.3",
 	"gd": {
 		"win": "2.2074",
 		"android": "2.2074",
@@ -30,6 +30,7 @@
     ],
 	"settings": {
 		"left-align": {
+			
             "name": "Left Align Groups",
 			"description": "Align groups to the left like vanilla GD",
             "type": "bool",

--- a/mod.json
+++ b/mod.json
@@ -28,6 +28,11 @@
             "importance": "suggested"
 		}
     ],
+	"api": {
+		"include": [
+			"api/*.hpp"
+		]
+	},
 	"settings": {
 		"left-align": {
 			
@@ -38,6 +43,6 @@
         }
 	},
 	"tags": [
-		"editor", "enhancement"
+		"editor", "enhancement", "api"
 	]
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -198,7 +198,7 @@ class $modify(MySetGroupIDLayer, SetGroupIDLayer) {
         float m_scrollPos = INT_MIN;
         std::unordered_map<std::string, short> m_namedIDs;
 
-        EventListener<EventFilter<GroupViewUpdateEvent>> m_apiListener;
+        EventListener<EventFilter<igv::GroupViewUpdateEvent>> m_apiListener;
     };
 
     static void onModify(auto& self) {
@@ -259,10 +259,10 @@ class $modify(MySetGroupIDLayer, SetGroupIDLayer) {
         }
         regenerateGroupView();
 
-        m_fields->m_apiListener.bind([this](GroupViewUpdateEvent* event) {
+        m_fields->m_apiListener.bind([this](igv::GroupViewUpdateEvent* event) {
             regenerateGroupView();
 
-            return ListenerResult::Stop;
+            return ListenerResult::Propagate;
         }
         );
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -473,7 +473,7 @@ class $modify(MySetGroupIDLayer, SetGroupIDLayer) {
         int uuid = obj->m_uniqueID;
         std::vector<int> parents;
 
-        for (auto [k, v] : CCDictionaryExt<int, CCArray*>(lel->m_unknownE40)) {
+        for (auto [k, v] : CCDictionaryExt<int, CCArray*>(lel->m_parentGroupIDs)) {
             if (k == uuid) {
                 for (auto val : CCArrayExt<CCInteger*>(v)) {
                     parents.push_back(val->getValue());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include <Geode/Geode.hpp>
+#include "../api/GroupViewUpdateEvent.hpp"
 #include <Geode/modify/SetGroupIDLayer.hpp>
 #include <Geode/modify/CCScrollLayerExt.hpp>
 #include <Geode/modify/SetupRandAdvTriggerPopup.hpp>
@@ -196,6 +197,8 @@ class $modify(MySetGroupIDLayer, SetGroupIDLayer) {
         int m_lastRemoved = 0;
         float m_scrollPos = INT_MIN;
         std::unordered_map<std::string, short> m_namedIDs;
+
+        EventListener<EventFilter<GroupViewUpdateEvent>> m_apiListener;
     };
 
     static void onModify(auto& self) {
@@ -255,6 +258,13 @@ class $modify(MySetGroupIDLayer, SetGroupIDLayer) {
             schedule(schedule_selector(MySetGroupIDLayer::checkNamedIDs));
         }
         regenerateGroupView();
+
+        m_fields->m_apiListener.bind([this](GroupViewUpdateEvent* event) {
+            regenerateGroupView();
+
+            return ListenerResult::Stop;
+        }
+        );
 
         return true;
     }


### PR DESCRIPTION
### THE CHANGELOG AND MOD.JSON ARE _NOT_ UPDATED, EDIT THEM ACCORDING TO YOUR VERSIONING AND DESCRIPTION PREFERENCES

I've found your mod very handy and convenient to use, but I've had one small problem while using it - since it hides and replaces Rob's group menu and the mod has a single hook (init), there is no way to signal your menu to update. One solution I propose to this is an addition of an event based API - this way, any mod could use this mod as a dependency and update the group menu arbitrarily. Hope you find this addition worth merging, since I believe it will ease development of mods that touch this part of the editor and will drastically help with compatibility.

Best regards,
Fryy_55 💜